### PR TITLE
fix: add sanity checks to set_read_config (CS-040)

### DIFF
--- a/contracts/messengers/LZBlockRelay.vy
+++ b/contracts/messengers/LZBlockRelay.vy
@@ -152,6 +152,17 @@ def set_read_config(
         not _is_enabled and _mainnet_eid == 0 and _mainnet_view == empty(address)
     ), "Invalid read config"
 
+    # Check for redundant operations
+    if _is_enabled and self.read_enabled:
+        assert self.read_channel != _read_channel, "Read channel already enabled"
+    
+    if not _is_enabled and not self.read_enabled:
+        assert False, "Read channel already disabled"
+    
+    # If changing from one enabled channel to another, clear old peer
+    if self.read_enabled and _is_enabled and self.read_channel != _read_channel:
+        OApp._setPeer(self.read_channel, convert(empty(address), bytes32))
+
     self.read_enabled = _is_enabled
     self.read_channel = _read_channel
     self.mainnet_eid = _mainnet_eid


### PR DESCRIPTION
## Summary
- Added sanity checks to prevent redundant operations in `set_read_config`
- Check if read channel is already enabled before enabling again
- Check if read channel is already disabled before disabling again  
- Clear old peer mapping when switching between read channels

## Audit Finding
Addresses CS-CURVE_BLOCKHASH-040: Missing sanity check in set_read_config

## Test plan
- [x] Updated `test_set_read_config` to verify redundant operations fail
- [x] Added `test_set_read_config_channel_switch` to verify channel switching
- [x] All tests pass successfully

Created using Claude Code