### PR TITLE
docs: add missing natspec for lzReceive and modules (CS-039)

### DIFF
--- a/contracts/messengers/LZBlockRelay.vy
+++ b/contracts/messengers/LZBlockRelay.vy
@@ -501,6 +501,11 @@ def lzReceive(
     @dev Two types of messages:
          1. Read responses (from read channel)
          2. Regular messages (block hash broadcasts from other chains)
+    @param _origin Origin information containing srcEid, sender, and nonce
+    @param _guid Global unique identifier for the message
+    @param _message The encoded message payload containing block number and hash
+    @param _executor Address of the executor for the message
+    @param _extraData Additional data passed by the executor
     """
     # Verify message source
     OApp._lzReceive(_origin, _guid, _message, _executor, _extraData)

--- a/contracts/modules/oapp_vyper/OptionsBuilder.vy
+++ b/contracts/modules/oapp_vyper/OptionsBuilder.vy
@@ -1,10 +1,9 @@
 # pragma version 0.4.2
 
 """
+@title LayerZero Options Builder
 @license Copyright (c) Curve.Fi, 2025 - all rights reserved
-
 @author curve.fi
-
 @custom:security security@curve.fi
 """
 

--- a/contracts/modules/oapp_vyper/ReadCmdCodecV1.vy
+++ b/contracts/modules/oapp_vyper/ReadCmdCodecV1.vy
@@ -1,11 +1,9 @@
 # pragma version 0.4.2
 
 """
-
+@title LayerZero Read Command Codec V1
 @license Copyright (c) Curve.Fi, 2025 - all rights reserved
-
 @author curve.fi
-
 @custom:security security@curve.fi
 """
 

--- a/contracts/modules/oapp_vyper/VyperConstants.vy
+++ b/contracts/modules/oapp_vyper/VyperConstants.vy
@@ -1,11 +1,10 @@
 # pragma version 0.4.2
 
 """
+@title LayerZero Vyper Constants
 @license Copyright (c) Curve.Fi, 2025 - all rights reserved
-
 @notice Vyper does not allow truly dynamic byte arrays, and requires constants to cap the size of the array.
 This file contains such constants for the LayerZero OApp.
-
 @dev IMPORTANT: Tune these down as much as possible according to intended use case to save on gas.
 
 @author curve.fi


### PR DESCRIPTION
## Summary
Added missing natspec documentation for:

### LZBlockRelay
- Added @param documentation for all parameters in `lzReceive` function

### Module documentation
- Added @title to ReadCmdCodecV1.vy
- Added @title to OptionsBuilder.vy  
- Added @title to VyperConstants.vy

## Audit Finding
Addresses CS-CURVE_BLOCKHASH-039: Missing natspec documentation (partial - LZBlockRelay lzReceive and module titles)

## Test plan
- [x] Documentation-only changes, no functional impact
- [x] Contract compiles successfully

Created using Claude Code