### PR TITLE
fix: remove setReadChannel export (CS-045)

### DIFF
--- a/contracts/messengers/LZBlockRelay.vy
+++ b/contracts/messengers/LZBlockRelay.vy
@@ -58,7 +58,6 @@ exports: (
     OApp.endpoint,
     OApp.peers,
     OApp.setDelegate,
-    OApp.setReadChannel,
     OApp.isComposeMsgSender,
     OApp.allowInitializePath,
     OApp.nextNonce,


### PR DESCRIPTION
## Summary
Removed the export of `OApp.setReadChannel` from LZBlockRelay to prevent bypassing validation logic.

## Problem
The contract exports `setReadChannel` which allows direct manipulation of the read channel peer without the proper validation and state updates that `set_read_config` provides. This could lead to inconsistent state.

## Solution
Removed the export. Users must use `set_read_config` which properly validates parameters and maintains consistent state across all read-related variables.

## Audit Finding
Addresses CS-CURVE_BLOCKHASH-045: setReadChannel export bypasses set_read_config validation

## Test plan
- [x] Verified `test_set_read_config` still passes
- [x] No tests rely on the exported setReadChannel function

Created using Claude Code