### PR TITLE
fix: remove misleading committer field from SubmitBlockHeader event (CS-046)

### DIFF
--- a/contracts/BlockOracle.vy
+++ b/contracts/BlockOracle.vy
@@ -53,7 +53,6 @@ event ApplyBlock:
 
 
 event SubmitBlockHeader:
-    committer: indexed(address)
     block_number: indexed(uint256)
     block_hash: bytes32
 
@@ -292,7 +291,6 @@ def submit_block_header(_header_data: bh_rlp.BlockHeader):
         self.last_confirmed_header = _header_data
 
     log  SubmitBlockHeader(
-        committer=msg.sender,
         block_number=_header_data.block_number,
         block_hash=_header_data.block_hash,
     )


### PR DESCRIPTION
## Summary
Removed the `committer` field from the `SubmitBlockHeader` event as it always shows the header_verifier address and provides no useful information.

## Problem
- The event logs `msg.sender` as "committer" but this is always the header_verifier contract
- The actual submitter is not tracked, making the field misleading
- The field provides no useful information since it's always the same address

## Solution
- Removed the `committer` field from the event definition
- Updated the log statement to exclude this parameter
- This is a breaking change for event consumers

## Audit Finding
Addresses CS-CURVE_BLOCKHASH-046: SubmitBlockHeader event committer field is misleading

## Test plan
- [x] Contract compiles successfully  
- [x] Event emission works without the committer field

Created using Claude Code