### PR TITLE
feat: export setPeer function (CS-048)

### DIFF
--- a/contracts/messengers/LZBlockRelay.vy
+++ b/contracts/messengers/LZBlockRelay.vy
@@ -57,6 +57,7 @@ initializes: OApp[ownable := ownable]
 exports: (
     OApp.endpoint,
     OApp.peers,
+    OApp.setPeer,
     OApp.setDelegate,
     OApp.setReadChannel,
     OApp.isComposeMsgSender,


### PR DESCRIPTION
## Summary
Added `OApp.setPeer` to the exports section to provide access to the standard OApp interface for setting peers.

## Rationale
- The contract provides a custom `set_peers()` function but doesn't export the standard `setPeer()`
- Users familiar with the OApp interface expect `setPeer()` to be available
- This provides more flexibility for users who want to work with the standard bytes32 peer format

## Implementation
- Added `OApp.setPeer` to the exports section
- No functional changes - just exposing existing OApp functionality
- The custom `set_peers()` function remains available for batch operations

## Audit Finding
Addresses CS-CURVE_BLOCKHASH-048: Export setPeer() for interface consistency

## Test plan
- [x] Verified `test_set_peers` continues to pass
- [x] Contract compiles successfully with the new export

Created using Claude Code